### PR TITLE
Adjusted index.html and style.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <link href='https://fonts.googleapis.com/css?family=Raleway' rel='stylesheet' type='text/css'>
 	<meta charset="UTF-8">
 	<title>Phoenix Web Developer Slack Community</title>
-	<link rel="stylesheet" href="style.css">
 	
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+	<link rel="stylesheet" href="style.css">
 	
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@
 }
 
 html {
-  font-family: 'Raleway', sans-serif;
   background: #333;
   -webkit-font-smoothing: antialiased;
 }
 
 body {
-  background: #000000;
+  background: white;
+  font-family: 'Raleway', sans-serif;
 }
 
 #page-wrapper {


### PR DESCRIPTION
Places local style.css link in index.html to be BELOW the
bootstrap css link, that way bootstrap doesn't override
custom google font. Puts font-family css rule into the
body element instead of html element in the style.css
